### PR TITLE
Patch fix wrong path

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Restarting in 9 seconds...
 
 7）Modify the `printf("Hello world!\n")` in the `app_main()` function of `hello_world` to be `printf("Hello world, Hello esp32!\n")`, and then run command `idf.py build` to build a new firmware.   
 
-8）Execute the command `custom_ota_gen.py -hv v2 -c xz -d ddelta -i build/hello_world.bin -b current_app.bin`, the custom_ota_binaries directory will be generated in this directory; the patch file `patch.xz.packed` will be included in the custom_ota_binaries directory.
+8）Execute the command ` bootloader_components/tools/custom_ota_gen.py -hv v2 -c xz -d ddelta -i build/hello_world.bin -b current_app.bin`, the custom_ota_binaries directory will be generated in this directory; the patch file `patch.xz.packed` will be included in the custom_ota_binaries directory.
 
 9）Run command `esptool.py -p PORT --after no_reset write_flash 0x220000 custom_ota_binaries/patch.xz.packed` to burn the patch file into the ESP device's `storage` partition. Please note that the parameter `PORT` should be replaced with the actual port of your device.    
 

--- a/tools/custom_ota_gen.py
+++ b/tools/custom_ota_gen.py
@@ -187,7 +187,7 @@ def main():
         if delta_type == 'ddelta':
             update_ddelta_library_path()
             uncompressed_patch = ''.join([cpmoressed_app_directory,'/','patch'])
-            ret = subprocess.call('./bootloader_components/tools/ddelta_generate {0} {1} {2}'.format(base_file, src_file, uncompressed_patch), shell = True)
+            ret = subprocess.call('bootloader_components/tools/ddelta_generate {0} {1} {2}'.format(base_file, src_file, uncompressed_patch), shell = True)
             # print('xz compress cmd return: {}'.format(ret))
             if ret:
                 raise Exception("ddelta_gen cmd failed")


### PR DESCRIPTION
Fix the path for the subprocess of `ddelta_generate`. The script can now be executed from the root directory of the project, based on the `README`

```
bootloader_components        — Bootloader directory      
  + esp-xz                   - Esp xz decompress lib
  + main                     - Main source files of the bootloader
main 				         — Main source files of the application 
server_certs                 — The directory used to store certificate
Makefile/CMakeLists.txt    — Makefiles of the application project
```

After running the script the results will look like this

```
bootloader_components        — Bootloader directory      
custom_ota_binaries             — Output files
  + esp-xz                   - Esp xz decompress lib
  + main                     - Main source files of the bootloader
main 				         — Main source files of the application 
server_certs                 — The directory used to store certificate
Makefile/CMakeLists.txt    — Makefiles of the application project
```

Also updated `README` to handle misunderstandings in the execution of `custom_ota_gen.py`.